### PR TITLE
Fix RSS date format

### DIFF
--- a/rss_crawler.go
+++ b/rss_crawler.go
@@ -2,6 +2,7 @@ package feeder
 
 import (
 	"encoding/xml"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -59,6 +60,7 @@ func convertRssItemToItem(i *feeds.RssItem) (*Item, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Parse Error")
 	}
+	fmt.Println(t)
 	item := &Item{
 		Title:       i.Title,
 		Link:        &Link{Href: i.Link},

--- a/rss_crawler.go
+++ b/rss_crawler.go
@@ -47,11 +47,18 @@ func (crawler *rssCrawler) Crawl() ([]*Item, error) {
 }
 
 func convertRssItemToItem(i *feeds.RssItem) (*Item, error) {
-	t, err := time.Parse(time.RFC1123, i.PubDate)
+	layouts := []string{time.RFC1123, time.RFC1123Z}
+	var t time.Time
+	var err error
+	for _, layout := range layouts {
+		t, err = time.Parse(layout, i.PubDate)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "Parse Error")
 	}
-
 	item := &Item{
 		Title:       i.Title,
 		Link:        &Link{Href: i.Link},

--- a/rss_crawler.go
+++ b/rss_crawler.go
@@ -47,7 +47,7 @@ func (crawler *rssCrawler) Crawl() ([]*Item, error) {
 }
 
 func convertRssItemToItem(i *feeds.RssItem) (*Item, error) {
-	t, err := time.Parse("Mon, 2 Jan 2006 15:04:05 -0700", i.PubDate)
+	t, err := time.Parse(time.RFC1123, i.PubDate)
 	if err != nil {
 		return nil, errors.Wrap(err, "Parse Error")
 	}

--- a/rss_crawler_test.go
+++ b/rss_crawler_test.go
@@ -59,7 +59,7 @@ func TestRSSFetch(t *testing.T) {
 			Name: "name",
 		},
 		Description: "summary_content",
-		ID:          "id",
+		ID:          "id2",
 		Updated:     nil,
 		Created:     &published,
 		Enclosure: &feeder.Enclosure{

--- a/rss_crawler_test.go
+++ b/rss_crawler_test.go
@@ -48,6 +48,26 @@ func TestRSSFetch(t *testing.T) {
 			Length: "0",
 		},
 		Content: "",
+	}, {
+		Title: "title2",
+		Link: &feeder.Link{
+			Href: "http://example.com",
+			Rel:  "",
+		},
+		Source: nil,
+		Author: &feeder.Author{
+			Name: "name",
+		},
+		Description: "summary_content",
+		ID:          "id",
+		Updated:     nil,
+		Created:     &published,
+		Enclosure: &feeder.Enclosure{
+			URL:    "http://example.com/image.png",
+			Type:   "image/png",
+			Length: "0",
+		},
+		Content: "",
 	}}
 
 	crawler := feeder.NewRSSCrawler(server.URL + "/rss")

--- a/rss_test.xml
+++ b/rss_test.xml
@@ -4,12 +4,12 @@
     <title>title</title>
     <link>http://example.com</link>
     <description>subtitle</description>
-    <lastBuildDate>Tue, 01 Jan 2019 00:200:00 +0900</lastBuildDate>
+    <lastBuildDate>Tue, 01 Jan 2019 00:200:00 JST</lastBuildDate>
         <item>
             <title>title</title>
             <link>http://example.com</link>
             <description>summary_content</description>
-            <pubDate>Tue, 01 Jan 2019 00:00:00 +0900</pubDate>
+            <pubDate>Tue, 01 Jan 2019 00:00:00 JST</pubDate>
             <guid isPermalink="false">id</guid>
             <author>name</author>
             <enclosure url="http://example.com/image.png" type="image/png" length="0" />

--- a/rss_test.xml
+++ b/rss_test.xml
@@ -14,5 +14,14 @@
             <author>name</author>
             <enclosure url="http://example.com/image.png" type="image/png" length="0" />
         </item>
+        <item>
+            <title>title2</title>
+            <link>http://example.com</link>
+            <description>summary_content</description>
+            <pubDate>Tue, 01 Jan 2019 00:00:00 +0900</pubDate>
+            <guid isPermalink="false">id</guid>
+            <author>name</author>
+            <enclosure url="http://example.com/image.png" type="image/png" length="0" />
+        </item>
   </channel>
 </rss>

--- a/rss_test.xml
+++ b/rss_test.xml
@@ -19,7 +19,7 @@
             <link>http://example.com</link>
             <description>summary_content</description>
             <pubDate>Tue, 01 Jan 2019 00:00:00 +0900</pubDate>
-            <guid isPermalink="false">id</guid>
+            <guid isPermalink="false">id2</guid>
             <author>name</author>
             <enclosure url="http://example.com/image.png" type="image/png" length="0" />
         </item>


### PR DESCRIPTION
## What
Change RSS date format to RFC1123.

## Why
According to [RSS specification](http://validator.w3.org/feed/docs/rss2.html) , date fields (ex. `pubDate` ) format is RFC822 or RFC1123.
Currently, parsing date string in the format specified by RFC1123 (like `Sat, 26 Sep 2020 08:11:05 GMT` ) fails with parse error.